### PR TITLE
Allow fully qualified global constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require": {
         "php": ">=7.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "slevomat/coding-standard": "^8.8",
+        "slevomat/coding-standard": "^8.14",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {

--- a/ptscs/Sniffs/PSR12/FileHeaderSniff.php
+++ b/ptscs/Sniffs/PSR12/FileHeaderSniff.php
@@ -23,7 +23,7 @@ final class FileHeaderSniff implements Sniff
      */
     public function register()
     {
-        return [T_OPEN_TAG];
+        return [\T_OPEN_TAG];
     }
 
     /**
@@ -41,8 +41,8 @@ final class FileHeaderSniff implements Sniff
 
         $possibleHeaders = [];
 
-        $searchFor             = Tokens::$ooScopeTokens;
-        $searchFor[T_OPEN_TAG] = T_OPEN_TAG;
+        $searchFor              = Tokens::$ooScopeTokens;
+        $searchFor[\T_OPEN_TAG] = \T_OPEN_TAG;
 
         $openTag = $stackPtr;
         do {
@@ -95,7 +95,7 @@ final class FileHeaderSniff implements Sniff
             if ($openTag !== 0) {
                 // Allow for hashbang lines.
                 $hashbang = false;
-                if ($tokens[($openTag - 1)]['code'] === T_INLINE_HTML) {
+                if ($tokens[($openTag - 1)]['code'] === \T_INLINE_HTML) {
                     $content = \trim($tokens[($openTag - 1)]['content']);
                     if (\substr($content, 0, 2) === '#!') {
                         $hashbang = true;
@@ -127,7 +127,7 @@ final class FileHeaderSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($next === false) {
             return [];
         }
@@ -142,19 +142,19 @@ final class FileHeaderSniff implements Sniff
         $foundDocblock = false;
 
         $commentOpeners = Tokens::$scopeOpeners;
-        unset($commentOpeners[T_NAMESPACE]);
-        unset($commentOpeners[T_DECLARE]);
-        unset($commentOpeners[T_USE]);
-        unset($commentOpeners[T_IF]);
-        unset($commentOpeners[T_WHILE]);
-        unset($commentOpeners[T_FOR]);
-        unset($commentOpeners[T_FOREACH]);
-        unset($commentOpeners[T_DO]);
-        unset($commentOpeners[T_TRY]);
+        unset($commentOpeners[\T_NAMESPACE]);
+        unset($commentOpeners[\T_DECLARE]);
+        unset($commentOpeners[\T_USE]);
+        unset($commentOpeners[\T_IF]);
+        unset($commentOpeners[\T_WHILE]);
+        unset($commentOpeners[\T_FOR]);
+        unset($commentOpeners[\T_FOREACH]);
+        unset($commentOpeners[\T_DO]);
+        unset($commentOpeners[\T_TRY]);
 
         do {
             switch ($tokens[$next]['code']) {
-                case T_DOC_COMMENT_OPEN_TAG:
+                case \T_DOC_COMMENT_OPEN_TAG:
                     if ($foundDocblock === true) {
                     // Found a second docblock, so start of code.
                         break(2);
@@ -168,7 +168,7 @@ final class FileHeaderSniff implements Sniff
                         }
 
                         if (
-                            $tokens[$docToken]['code'] === T_ATTRIBUTE
+                            $tokens[$docToken]['code'] === \T_ATTRIBUTE
                             && isset($tokens[$docToken]['attribute_closer']) === true
                         ) {
                             $docToken = $tokens[$docToken]['attribute_closer'];
@@ -190,7 +190,7 @@ final class FileHeaderSniff implements Sniff
                         $annotation = false;
                         for ($i = $next; $i < $end; $i++) {
                             if (
-                                $tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                                $tokens[$i]['code'] === \T_DOC_COMMENT_TAG
                                 && \strtolower($tokens[$i]['content']) === '@var'
                             ) {
                                 $annotation = true;
@@ -210,8 +210,8 @@ final class FileHeaderSniff implements Sniff
 
                     $next = $end;
                     break;
-                case T_DECLARE:
-                case T_NAMESPACE:
+                case \T_DECLARE:
+                case \T_NAMESPACE:
                     if (isset($tokens[$next]['scope_opener']) === true) {
                     // If this statement is using bracketed syntax, it doesn't
                     // apply to the entire files and so is not part of header.
@@ -229,10 +229,10 @@ final class FileHeaderSniff implements Sniff
 
                     $next = $end;
                     break;
-                case T_USE:
+                case \T_USE:
                     $type    = 'use';
                     $useType = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
-                    if ($useType !== false && $tokens[$useType]['code'] === T_STRING) {
+                    if ($useType !== false && $tokens[$useType]['code'] === \T_STRING) {
                         $content = \strtolower($tokens[$useType]['content']);
                         if ($content === 'function' || $content === 'const') {
                             $type .= ' ' . $content;
@@ -266,7 +266,7 @@ final class FileHeaderSniff implements Sniff
                     break(2);
             }//end switch
 
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);
+            $next = $phpcsFile->findNext(\T_WHITESPACE, ($next + 1), null, true);
         } while ($next !== false);
 
         return $headerLines;
@@ -295,7 +295,7 @@ final class FileHeaderSniff implements Sniff
                 // We're at the end of the current header block.
                 // Make sure there is a single blank line after
                 // this block.
-                $next = $phpcsFile->findNext(T_WHITESPACE, ($line['end'] + 1), null, true);
+                $next = $phpcsFile->findNext(\T_WHITESPACE, ($line['end'] + 1), null, true);
                 if ($next !== false && $tokens[$next]['line'] !== ($tokens[$line['end']]['line'] + 2)) {
                     $error = 'Header blocks must be separated by a single blank line';
                     $fix   = $phpcsFile->addFixableError($error, $line['end'], 'SpacingAfterBlock');
@@ -335,7 +335,7 @@ final class FileHeaderSniff implements Sniff
             } elseif ($headerLines[($i + 1)]['type'] === $line['type']) {
                 // Still in the same block, so make sure there is no
                 // blank line after this statement.
-                $next = $phpcsFile->findNext(T_WHITESPACE, ($line['end'] + 1), null, true);
+                $next = $phpcsFile->findNext(\T_WHITESPACE, ($line['end'] + 1), null, true);
                 if ($tokens[$next]['line'] > ($tokens[$line['end']]['line'] + 1)) {
                     $error = 'Header blocks must not contain blank lines';
                     $fix   = $phpcsFile->addFixableError($error, $line['end'], 'SpacingInsideBlock');

--- a/ptscs/ruleset.xml
+++ b/ptscs/ruleset.xml
@@ -179,11 +179,13 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias" />
 
     <!-- Fully qualified exceptions and global functions -->
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants" />
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions" />
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>
             <property name="searchAnnotations" value="true" />
             <property name="allowFullyQualifiedGlobalFunctions" value="true" />
+            <property name="allowFullyQualifiedGlobalConstants" value="true" />
         </properties>
     </rule>
 

--- a/tests/SniffTestCase.php
+++ b/tests/SniffTestCase.php
@@ -49,8 +49,8 @@ abstract class SniffTestCase extends TestCase
         $filename = \str_replace('Test', '', \array_pop($names));
         $paths    = \array_merge([__DIR__], \array_slice($names, 2), ['_data'], [$filename . '.php.inc']);
 
-        $filepath = \implode(DIRECTORY_SEPARATOR, $paths);
-        $this->assertFileExists($filepath);
+        $filepath = \implode(\DIRECTORY_SEPARATOR, $paths);
+        $this->assertFileExists($filepath, "File $filepath is not exists");
 
         $sniff = new SniffAssertion($filepath, $this->standard, $this->excludes);
         $sniff->assertError($this, $errorData);

--- a/tests/Sniffs/Slevomat/FullyQualifiedTest.php
+++ b/tests/Sniffs/Slevomat/FullyQualifiedTest.php
@@ -18,7 +18,8 @@ final class FullyQualifiedTest extends SniffTestCase
     {
         yield[
           [
-            new ErrorData(11, 'SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions'),
+            new ErrorData(13, 'SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions'),
+            new ErrorData(15, 'SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions'),
           ],
         ];
     }

--- a/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.fixed
+++ b/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.fixed
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use App\Entity\{User,Role};
+use App\Entity\{User, Role as EntityRole};
 
 final class Foobar
 {
@@ -12,7 +12,7 @@ final class Foobar
     private $user;
 
     /**
-     * @var Role
+     * @var EntityRole
      */
     private $role;
 }

--- a/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.inc
+++ b/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.inc
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use App\Entity\{User,Role};
+use App\Entity\{ User, Role as EntityRole};
 
 final class Foobar
 {
@@ -12,7 +12,7 @@ final class Foobar
     private $user;
 
     /**
-     * @var Role
+     * @var EntityRole
      */
     private $role;
 }

--- a/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.inc
+++ b/tests/Sniffs/Slevomat/_data/DisallowGroupUse.php.inc
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use App\Entity\{ User, Role as EntityRole};
+use App\Entity\{User, Role as EntityRole};
 
 final class Foobar
 {

--- a/tests/Sniffs/Slevomat/_data/FullyQualified.php.fixed
+++ b/tests/Sniffs/Slevomat/_data/FullyQualified.php.fixed
@@ -8,6 +8,8 @@ final class FooException extends Exception
 
     public function __construct()
     {
-        $this->values = \explode(DIRECTORY_SEPARATOR, __DIR__);
+        $this->values = \explode(\DIRECTORY_SEPARATOR, __DIR__);
+
+        echo \parse_url('localhost', \PHP_URL_QUERY);
     }
 }

--- a/tests/Sniffs/Slevomat/_data/FullyQualified.php.inc
+++ b/tests/Sniffs/Slevomat/_data/FullyQualified.php.inc
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use const PHP_URL_QUERY;
+
 final class FooException extends Exception
 {
     private $values;
@@ -9,5 +11,7 @@ final class FooException extends Exception
     public function __construct()
     {
         $this->values = explode(DIRECTORY_SEPARATOR, __DIR__);
+
+        echo parse_url('localhost', PHP_URL_QUERY);
     }
 }


### PR DESCRIPTION
This PR will add support to fully qualified global constant. For example
```php
use const PHP_URL_QUERY;

// 
var_dump(explode(DIRECTORY_SEPARATOR, __DIR__));
echo parse_url('localhost', PHP_URL_QUERY);
```
will be formatted to
```php
var_dump(explode(\DIRECTORY_SEPARATOR, __DIR__));
echo parse_url('localhost', \PHP_URL_QUERY);
```