### PR TITLE
Disallow loose comparison operator

### DIFF
--- a/ptscs/ruleset.xml
+++ b/ptscs/ruleset.xml
@@ -204,6 +204,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation" />
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
 
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators" />
 
     <!--++++++++++++++++++++++++++++++++++++
     Code analysis

--- a/tests/Sniffs/Slevomat/Operators/DisallowEqualOperatorsTest.php
+++ b/tests/Sniffs/Slevomat/Operators/DisallowEqualOperatorsTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Ptscs\Tests\Sniffs\Slevomat\Operators;
+
+use Iterator;
+use Ptscs\Tests\SniffTestCase;
+use Ptscs\Tests\Utils\ErrorData;
+
+final class DisallowEqualOperatorsTest extends SniffTestCase
+{
+    public static function provideTestData(): Iterator
+    {
+        yield[
+          [
+            new ErrorData(5, 'SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator'),
+          ],
+        ];
+    }
+}

--- a/tests/Sniffs/Slevomat/Operators/_data/DisallowEqualOperators.php.fixed
+++ b/tests/Sniffs/Slevomat/Operators/_data/DisallowEqualOperators.php.fixed
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+$a = null;
+
+if ($a === '' || $a !== null) {
+    $a = 0;
+}

--- a/tests/Sniffs/Slevomat/Operators/_data/DisallowEqualOperators.php.inc
+++ b/tests/Sniffs/Slevomat/Operators/_data/DisallowEqualOperators.php.inc
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+$a = null;
+
+if ($a == '' || $a != null) {
+    $a = 0;
+}


### PR DESCRIPTION
| Q       | A                          |
|---------|----------------------------|
| PR Type | Feature |
| Issues  | Fix #                      |
| License | MIT                        |

This PR will disallow the usage of loose PHP comparison operators (`==` and `!=`).
