### PR TITLE
Update PHP_CodeSniffer schema URL to canonical permalink

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <arg name="basepath" value="." />
     <arg name="colors" />

--- a/ptscs/ruleset.xml
+++ b/ptscs/ruleset.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd" -->
+xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd" -->
 
 <ruleset name="ptscs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
     <description>PSR-12 based PHP coding standard</description>
 
     <arg name="tab-width" value="4" />


### PR DESCRIPTION
PHP_CodeSniffer now provides a canonical permalink for the XML schema used in the `xsi:noNamespaceSchemaLocation` attribute of ruleset files. This replaces the previous `raw.githubusercontent.com` URL with https://schema.phpcodesniffer.com/phpcs.xsd.

See: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1094